### PR TITLE
lantiq-xrx200: add support for AVM FRITZ!Box 3370 (Hynix and Micron)

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -250,6 +250,7 @@ lantiq-xrx200
 
 * AVM
 
+  - FRITZ!Box 3370 (Hynix Nand, Micron Nand) [#lan_as_wan]_
   - FRITZ!Box 7360 (v1, v2) [#avmflash]_ [#lan_as_wan]_
   - FRITZ!Box 7360 SL [#avmflash]_ [#lan_as_wan]_
   - FRITZ!Box 7362 SL [#eva_ramboot]_ [#lan_as_wan]_

--- a/targets/lantiq-xrx200
+++ b/targets/lantiq-xrx200
@@ -1,3 +1,21 @@
+-- AVM
+
+device('avm-fritz-box-3370-rev-2-hynix-nand', 'avm_fritz3370-rev2-hynix', {
+        factory = false,
+        extra_images = {
+               {'-squashfs-eva-filesystem', '-eva-filesystem', '.bin'},
+               {'-squashfs-eva-kernel', '-eva-kernel', '.bin'},
+        },
+})
+
+device('avm-fritz-box-3370-rev-2-micron-nand', 'avm_fritz3370-rev2-micron', {
+        factory = false,
+        extra_images = {
+               {'-squashfs-eva-filesystem', '-eva-filesystem', '.bin'},
+               {'-squashfs-eva-kernel', '-eva-kernel', '.bin'},
+        },
+})
+
 device('avm-fritz-box-7360-sl', 'avm_fritz7360sl', {
         factory = false,
         aliases = {'avm-fritz-box-7360-v1', 'avm-fritz-box-7360-v2'},


### PR DESCRIPTION
Support included for the Hynix and Micron NAND Variant.
Install via EVA Bootloader like discribed in the OpenWRT Commit:
https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=0b62fe5ed87ecac52301096b15abb69f96117c8c